### PR TITLE
Fixes recalculation of quality reports

### DIFF
--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -35,10 +35,11 @@ module QME
         filters = @parameter_values["filters"]
 
 
-        match = {'value.measure_id' => @measure_id,
+        match = {'value.measure_id'       => @measure_id,
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
                  'value.test_id'          => @parameter_values['test_id'],
+                 'value.expired_at'       => nil,
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         if(filters)
@@ -90,7 +91,7 @@ module QME
         supplemental_data = Hash[*keys.map{|k| [k,{QME::QualityReport::RACE => {},
                                                    QME::QualityReport::ETHNICITY => {},
                                                    QME::QualityReport::SEX => {},
-                                                   QME::QualityReport::PAYER => {}}]}.flatten]                                      
+                                                   QME::QualityReport::PAYER => {}}]}.flatten]
         keys.each do |pop_id|
           pline = build_query
 

--- a/lib/qme/map/measure_calculation_job.rb
+++ b/lib/qme/map/measure_calculation_job.rb
@@ -21,7 +21,7 @@ module QME
       def perform
         if !@quality_report.calculated? || @options['recalculate']
           map = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, @options.merge('start_time' => Time.now.to_i))
-          if @quality_report.patients_cached? || @options['recalculate']
+          if !@quality_report.patients_cached? || @options['recalculate']
             @quality_report.expire_patient_results
             tick('Starting MapReduce')
             map.map_records_into_measure_groups(@options['prefilter'])

--- a/lib/qme/map/measure_calculation_job.rb
+++ b/lib/qme/map/measure_calculation_job.rb
@@ -19,9 +19,10 @@ module QME
       end
 
       def perform
-        if !@quality_report.calculated?
+        if !@quality_report.calculated? || @options['recalculate']
           map = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, @options.merge('start_time' => Time.now.to_i))
-          if !@quality_report.patients_cached?
+          if @quality_report.patients_cached? || @options['recalculate']
+            @quality_report.expire_patient_results
             tick('Starting MapReduce')
             map.map_records_into_measure_groups(@options['prefilter'])
             tick('MapReduce complete')

--- a/lib/qme/quality_report.rb
+++ b/lib/qme/quality_report.rb
@@ -166,6 +166,10 @@ module QME
      QME::PatientCache.where(patient_cache_matcher)
     end
 
+    def expire_patient_results
+      patient_results.update_all("value.expired_at" => Time.now)
+    end
+
     def measure
       QME::QualityMeasure.where({"hqmf_id"=>self.measure_id, "sub_id" => self.sub_id}).first
     end
@@ -189,6 +193,7 @@ module QME
                'value.sub_id'           => self.sub_id,
                'value.effective_date'   => self.effective_date,
                'value.test_id'          => test_id,
+               'value.expired_at'       => nil,
                'value.manual_exclusion' => {'$in' => [nil, false]}}
 
       if(filters)


### PR DESCRIPTION
The recalculation option was being set on the quality report but not being persisted, so when `@quality_report.patients_cached? ` was being called the result was true. 

This PR also marks the associated patient results as expired so that they aren't used in the future and instead are recalculated.